### PR TITLE
Removing Updation of Profiles during Creation & Deletion of segments

### DIFF
--- a/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
@@ -280,7 +280,7 @@ public class SegmentServiceImpl extends AbstractServiceImpl implements SegmentSe
 
         // make sure we update the name and description metadata that might not match, so first we remove the entry from the map
         persistenceService.save(segment, null, true);
-        updateExistingProfilesForSegment(segment);
+//        updateExistingProfilesForSegment(segment);
     }
 
     private boolean checkSegmentDeletionImpact(Condition condition, String segmentToDeleteId) {
@@ -391,7 +391,7 @@ public class SegmentServiceImpl extends AbstractServiceImpl implements SegmentSe
             segmentCondition.setParameter("propertyName", "segments");
             segmentCondition.setParameter("comparisonOperator", "equals");
             segmentCondition.setParameter("propertyValue", segmentId);
-            updateProfilesSegment(segmentCondition, segmentId, false, false);
+//            updateProfilesSegment(segmentCondition, segmentId, false, false);
 
             // update impacted segments
             for (Segment segment : impactedSegments) {

--- a/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
+++ b/services/src/main/java/org/apache/unomi/services/impl/segments/SegmentServiceImpl.java
@@ -280,6 +280,8 @@ public class SegmentServiceImpl extends AbstractServiceImpl implements SegmentSe
 
         // make sure we update the name and description metadata that might not match, so first we remove the entry from the map
         persistenceService.save(segment, null, true);
+        // NOTE: Removing the updating the profiles. The profile will be updated with the modified segment list once
+        // the user becomes active.
 //        updateExistingProfilesForSegment(segment);
     }
 
@@ -391,6 +393,8 @@ public class SegmentServiceImpl extends AbstractServiceImpl implements SegmentSe
             segmentCondition.setParameter("propertyName", "segments");
             segmentCondition.setParameter("comparisonOperator", "equals");
             segmentCondition.setParameter("propertyValue", segmentId);
+            // NOTE: Removing the updating the profiles. The profile will be updated with the modified segment list once
+            // the user becomes active.
 //            updateProfilesSegment(segmentCondition, segmentId, false, false);
 
             // update impacted segments
@@ -974,7 +978,9 @@ public class SegmentServiceImpl extends AbstractServiceImpl implements SegmentSe
                 Segment linkedSegment = getSegmentDefinition(linkedItem);
                 if (linkedSegment != null) {
                     logger.info("Start segment recalculation for segment: {} - {}", linkedSegment.getItemId(), linkedSegment.getMetadata().getName());
-                    updateExistingProfilesForSegment(linkedSegment);
+                    // NOTE: Removing the updating the profiles. The profile will be updated with the modified segment list once
+                    // the user becomes active.
+//                    updateExistingProfilesForSegment(linkedSegment);
                     continue;
                 }
 


### PR DESCRIPTION
Commenting out the updation of profiles with updated segments list during creation & deletion of segments. The profiles will get updated when they become active. This is done to avoid the bulk updates of profiles during creation/deletion of large segments, where it is resource intensive on both Unomi and DynamoDB.

Tested the following scenarios:
- Creation time of segment, profiles are not added to the segment
- After events are sent they are added to the profile
- If a segment is deleted the profiles having this segment are not updated immediately. but only when the profiles become active
- As new profiles are created, they are added to existing segments

> ⚠️ **Note**  
> Base branch for unomi changes is `rfk-unomi-v2.1`.  
> Please merge all the changes to `rfk-unomi-v2.1` branch only